### PR TITLE
Removed settings_errors call in sb-bar-admin-display.php

### DIFF
--- a/admin/partials/sb-bar-admin-display.php
+++ b/admin/partials/sb-bar-admin-display.php
@@ -18,7 +18,6 @@ flush_rewrite_rules();
 ?>
 <div class="wrap">
 	<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
-	<?php settings_errors(); ?>
 	<div id="poststuff">
 		<div id="post-body" class="metabox-holder columns-2">
 			<div id="postbox-container-2" class="postbox-container">


### PR DESCRIPTION
settings_error() just causes 2 admin notices to show on save and is called by settings api anyway so it is not needed.
