### PR TITLE
Added option to show/hide "Share to Facebook" text

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: goran87
 Tags: share buttons,sticky bar, footer bar, previous next posts, time to read, progress bar, simple share, share icons, sticky share,author,social,twitter,facebook
 Requires at least: 3.0
 Tested up to: 4.3
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ We will add them slowly in new updates. Post on forums which one you need and we
 2. screenshot-2.png
 
 == Changelog ==
+
+= 1.1.2 =
+* Added option to show/hide the "Share on Facebook" text
 
 = 1.1.1 =
 * sbicon- class changed to sbicn to remove conflict with icomoon font

--- a/admin/class-sb-bar-admin.php
+++ b/admin/class-sb-bar-admin.php
@@ -229,6 +229,13 @@ class sb_bar_Admin {
 			$this->sb_bar . '-enable-options'
 		);
 		add_settings_field(
+			'smaller-facebook',
+			apply_filters( $this->sb_bar . '-smaller-facebook', __( 'Hide "Share on Facebook" Button text', $this->sb_bar ) ),
+			array( $this, 'smaller_facebook' ),
+			$this->sb_bar . '-enable',
+			$this->sb_bar . '-enable-options'
+		);
+		add_settings_field(
 			'disable-facebook',
 			apply_filters( $this->sb_bar . '-disable-facebook', __( 'Disable Facebook Button (Why would you do that?)', $this->sb_bar ) ),
 			array( $this, 'disable_facebook' ),
@@ -304,7 +311,7 @@ class sb_bar_Admin {
 	} // disable_bar_options_field()
 
 	/**
-	 * Enable Bar Field
+	 * Post Type Selection Field
 	 *
 	 * @since 		1.0.0
 	 * @return 		mixed 			The settings field
@@ -334,7 +341,7 @@ class sb_bar_Admin {
 			<?php }
 				
 		}  ?>
-			<p class="description">IMPORTANT: Bar will not show up untill one of these is checked.</p>
+			<p class="description">IMPORTANT: Bar will not show up until one of these is checked.</p>
 	<?php 
 	} // post_type()
 
@@ -658,6 +665,26 @@ class sb_bar_Admin {
 
 		<?php
 	} // disable_twitter()
+
+	/**
+	 * Smaller Facebook
+	 *
+	 * @since 		1.1.2
+	 * @return 		mixed 			The settings field
+	 */
+	public function smaller_facebook() {
+
+		$options 	= get_option( $this->sb_bar . '_options' );
+		$option 	= 0;
+
+		if ( ! empty( $options['smaller-facebook'] ) ) {
+			$option = $options['smaller-facebook'];
+		}
+
+		?><input type="checkbox" id="<?php echo $this->sb_bar; ?>_options[smaller-facebook]" name="<?php echo $this->sb_bar; ?>_options[smaller-facebook]" value="1" <?php checked( $option, 1 , true ); ?> />
+
+		<?php
+	} // smaller_facebook()
 
 	/**
 	 * Disable Facebook

--- a/admin/partials/sb-bar-admin-display.php
+++ b/admin/partials/sb-bar-admin-display.php
@@ -26,7 +26,7 @@ flush_rewrite_rules();
 						<h3 class="hndle"><span>Super Fast Footer Sticky Bar</span></h3>
 						<div class="inside">
 							<p>Thanks for installing Swifty Bar!</p>
-							<p>This plugin is lightweight and can easly replace mulitple of your plugins, such as social share, next/prev posts and time to read. 
+							<p>This plugin is lightweight and can easly replace multiple plugins, such as social share, next/prev posts and time to read. 
 							<br/>Its coded with best practice, it is super fast and you can expect regular updates with new options, so check back here often.</p>
 						</div>
 					</div>

--- a/includes/class-sb-bar.php
+++ b/includes/class-sb-bar.php
@@ -68,7 +68,7 @@ class sb_bar {
 	public function __construct() {
 
 		$this->sb_bar = 'sb_bar';
-		$this->version = '1.1.1';
+		$this->version = '1.1.2';
 
 		$this->load_dependencies();
 		$this->define_global_hooks(); // Call to new method that will show for both front and back

--- a/public/assets/css/sb-bar-public.css
+++ b/public/assets/css/sb-bar-public.css
@@ -263,6 +263,13 @@ body.single {
   display: inline-block;
   padding-left: 10px;
 }
+.sb_share li.sbfacebook.hidetext a {
+	padding: 0;
+	width: 34px;
+}
+.sb_share li.sbfacebook.hidetext a span {
+  display: none;
+}
 .sb_share li a.sbsoc-tw{
   background-color: #00c3f3;
 }

--- a/public/partials/sb-bar-public-display.php
+++ b/public/partials/sb-bar-public-display.php
@@ -178,7 +178,7 @@
 			<?php if(!isset($options["disable-share"])) { ?>
 			<ul class="sb_share">
 				<?php if(!isset($options["disable-facebook"])) { ?>
-			    <li class="sbfacebook"><a href="#" title="Share on Facebook" class="sbsoc-fb" target="_blank"><i class="sbicn-facebook"></i><span>Share on Facebook</span></a></li>
+			    <li class="sbfacebook"><a href="#" title="Share on Facebook" class="sbsoc-fb<?php if(isset($options["smaller-facebook"])) { ?> hidetext<?php } ?>" target="_blank"><i class="sbicn-facebook"></i><span>Share on Facebook</span></a></li>
 			    <?php } if(!isset($options["disable-twitter"])) { ?>
 			    <li class="sbtwitter"><a href="#" data-title="<?php the_title(); ?>" title="Share on Twitter" class="sbsoc-tw" target="_blank" ><i class="sbicn-twitter"></i><span>Share on Twitter</span></a></li>
 			    <?php } if(!isset($options["disable-googleplus"])) { ?>


### PR DESCRIPTION
First, let me say that I love this plugin and use it on my [personal blog](https://robertdevore.com)

I've noticed a few people asking about an option to hide the "Share on Facebook" text so the FB button looks like the rest of them, so I went ahead and did some updates to the plugin to add this option in.

I also updated a couple of other small things (spelling/grammar errors and duplicate note above a function)

Hopefully you like the changes enough to merge them in :+1: 
